### PR TITLE
add sourcemaps and update to latest module handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ Default value: []
 
 A list of macros you want to use. These can be npm modules or local files. Analagous to the `sjs -m` option.
 
+#### options.sourceMap
+Type: boolean
+Default value: false
+
+Generate sourcemaps along with JavaScript files
+
+#### options.nodeSourceMapSupport
+Type: boolean
+Default value: false
+
+Automatically load the
+[source-map-support](https://github.com/evanw/node-source-map-support)
+node module in generated files so errors automatically use sourcemaps. (You need to install the module with `npm install source-map-support`)
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/package.json
+++ b/package.json
@@ -27,10 +27,8 @@
     "grunt": "~0.4.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
-  },
-  "dependencies": {
-    "sweet.js": "~0.2.6"
+    "grunt": "~0.4.1",
+    "sweet.js": ">=0.2.6"
   },
   "keywords": [
     "gruntplugin"

--- a/tasks/sweet_js.js
+++ b/tasks/sweet_js.js
@@ -2,7 +2,7 @@
  * grunt-sweet.js
  * https://github.com/natefaubion/grunt-sweet.js
  *
- * Copyright (c) 2013 Nathan Faubion
+ * Copyright (c) 2013 Nathan Faubion, James Long
  * Licensed under the MIT license.
  */
 
@@ -20,7 +20,10 @@ function sweetCompile(grunt, code, dest, opts) {
     macros: opts.macros
   });
 
-  var compiled = result.code + '\n//# sourceMappingURL=' + mapfile;
+  var compiled = result.code;
+  if(opts.sourceMap) {
+      compiled += '\n//# sourceMappingURL=' + mapfile;
+  }
 
   if(opts.nodeSourceMapSupport) {
     compiled = "require('source-map-support').install(); " + compiled;
@@ -37,6 +40,7 @@ module.exports = function(grunt) {
   var moduleCache = {};
 
   grunt.registerMultiTask('sweet_js', 'Sweeten your JavaScript', function() {
+    var task = this;
     var options = this.options({
       modules: []
     });
@@ -81,7 +85,7 @@ module.exports = function(grunt) {
             outpath = base + '.js';
           }
 
-          grunt.log.warn('compiling ' + filepath);
+          grunt.log.writeln('compiling ' + filepath);
           sweetCompile(grunt, grunt.file.read(filepath), outpath, {
             filename: filepath,
             sourceMap: options.sourceMap,
@@ -108,5 +112,3 @@ module.exports = function(grunt) {
     return grunt.file.read(path);
   }
 };
-
-module.exports.compile = sweetCompile;

--- a/tasks/sweet_js.js
+++ b/tasks/sweet_js.js
@@ -44,8 +44,13 @@ module.exports = function(grunt) {
                   macros: moduleSrc
               });
 
-              grunt.file.write(outpath,
-                               result.code + '\n//# sourceMappingURL=' + mapfile);
+              var code = result.code + '\n//# sourceMappingURL=' + mapfile;
+
+              if(options.goodNodeErrors) {
+                  code = "require('source-map-support').install(); " + code;
+              }
+
+              grunt.file.write(outpath, code);
 
               if(result.sourceMap) {
                   grunt.file.write(outpath + '.map', result.sourceMap, 'utf8');

--- a/tasks/sweet_js.js
+++ b/tasks/sweet_js.js
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
         }
       });
 
-      if(f.dest) {
+      if(f.dest && f.src.length > 1) {
         var src = src.map(function(filepath) {
           return grunt.file.read(filepath);
         }).join('\n');
@@ -78,7 +78,10 @@ module.exports = function(grunt) {
           var base = path.join(path.dirname(filepath),
                                path.basename(filepath, ext));
 
-          if(ext == '.js') {
+          if(f.dest) {
+            outpath = f.dest;
+          }
+          else if(ext == '.js') {
             outpath = base + '.built.js';
           }
           else {


### PR DESCRIPTION
I updated the plugin to use the "macros" option to load in global macros instead of concat'ing a string and added sourcemap support. I also changed it so that it only works with ".sjs" files, and it compiles each file individually to a corresponding ".js" file.

After looking at your repos, you seem to just use a ".js" extension, so I'm open to making this more configurable somehow. I like having ".sjs" which compiles to ".js" and ".js.map" and I get good error handling easily, though I hate that each file is now 3 files.
